### PR TITLE
Limit the number of reported items

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -47,13 +47,14 @@ usage () {
   -i INCLUDE   optional  Comma delimited list of patterns within a container name to check
   -x EXCLUDE   optional  Comma delimited list of patterns within a container name to exclude from check
   -t TARGET    optional  Comma delimited list of images name to check
+  -n LIMIT     optional  In JSON output, when reporting lists of items (containers, images, etc.), limit the number of reported items to LIMIT. Default 0 (no limit).
 EOF
 }
 
 # Get the flags
 # If you add an option here, please
 # remember to update usage() above.
-while getopts bhl:c:e:i:x:t: args
+while getopts bhl:c:e:i:x:t:n: args
 do
   case $args in
   b) nocolor="nocolor";;
@@ -64,12 +65,17 @@ do
   i) include="$OPTARG" ;;
   x) exclude="$OPTARG" ;;
   t) imgList="$OPTARG" ;;
+  n) limit="$OPTARG" ;;
   *) usage; exit 1 ;;
   esac
 done
 
 if [ -z "$logger" ]; then
   logger="${myname}.log"
+fi
+
+if [ -z "$limit" ]; then
+  limit=0
 fi
 
 # Load output formating

--- a/output_lib.sh
+++ b/output_lib.sh
@@ -75,7 +75,22 @@ resulttestjson() {
       printf "\"result\": \"%s\", \"details\": \"%s\"}" "$1" "$2" | tee -a "$logger.json" 2>/dev/null 1>&2
   else
       # Result also includes details and a list of items. Add that directly to details and to an array property "items"
-      itemsJson=$(printf "["; ISEP=""; for item in $3; do printf "%s\"%s\"" "$ISEP" "$item"; ISEP=","; done; printf "]")
-      printf "\"result\": \"%s\", \"details\": \"%s: %s\", \"items\": %s}" "$1" "$2" "$3" "$itemsJson" | tee -a "$logger.json" 2>/dev/null 1>&2
+      # Also limit the number of items to $limit, if $limit is non-zero
+      if [ $limit != 0 ]; then
+        truncItems=""
+        ITEM_COUNT=0
+        for item in $3; do
+          truncItems="$truncItems $item"
+          ITEM_COUNT=$((ITEM_COUNT + 1));
+          if [ "$ITEM_COUNT" == "$limit" ]; then
+            truncItems="$truncItems (truncated)"
+            break;
+          fi
+        done
+      else
+        truncItems=$3
+      fi
+      itemsJson=$(printf "["; ISEP=""; ITEMCOUNT=0; for item in $truncItems; do printf "%s\"%s\"" "$ISEP" "$item"; ISEP=","; done; printf "]")
+      printf "\"result\": \"%s\", \"details\": \"%s: %s\", \"items\": %s}" "$1" "$2" "$truncItems" "$itemsJson" | tee -a "$logger.json" 2>/dev/null 1>&2
   fi
 }


### PR DESCRIPTION
In some evironments, there may be a very large number of images,
containers, etc not satisfying a given test. For example, in one
environment, we saw *378k* images not satisfying 4.6, mostly because
the customer was never cleaning up old images.

To avoid overly long lists of items, add a new option "-n LIMIT" that
limits the number of items included in JSON output. When the limit is
reached, the list will be truncated and a trailing (truncated) will be
added. Here's an example:

```
{"id": "5.9", "desc": "Ensure the host's network namespace is not
shared", "result": "WARN", "details": "Containers running with
networking mode 'host':  k8s_POD_storage-provisioner_kube-system_ef960ef5-62c5-11e9-802f-08002719228f_0
k8s_POD_kube-proxy-xfln8_kube-system_ee70c4c3-62c5-11e9-802f-08002719228f_0 (truncated)",
"items":
["k8s_POD_storage-provisioner_kube-system_ef960ef5-62c5-11e9-802f-08002719228f_0","k8s_POD_kube-proxy-xfln8_kube-system_ee70c4c3-62c5-11e9-802f-08002719228f_0","(truncated)"]},
```

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>